### PR TITLE
Integrate dependency of termoVideoManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-seneka
+SENEKA
 ======
+
+## Description
+This stack contains several drivers and algorithms that have been developed at Fraunhofer IPA for the SENEKA project.
+
+The different algorithms and drivers are described in more detail in their respective Readme's
+
+## Installation
+As this stack contains dependencies to non-released stacks and packages, please call the following commands from the folder where you cloned the seneka repository in:
+```bash
+rosinstall . seneka/seneka.rosinstall
+rosdep install seneka
+rosmake seneka
+```
+If everything has been set up correctly, the SENEKA stack should now be built.
+If not, check that you have checked out the optris_drivers package, that this package builds, that you can link to the respective libraries therein as well as to libudev-dev.

--- a/seneka.rosinstall
+++ b/seneka.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    uri: 'git://github.com/ohm-ros-pkg/optris_drivers.git'
+    local-name: optris_drivers
+    version: master

--- a/termoVideoManager/manifest.xml
+++ b/termoVideoManager/manifest.xml
@@ -16,6 +16,8 @@
   <depend package="opencv2"/>
   <depend package="image_transport"/>
   <depend package="optris_drivers"/>
+
+  <rosdep name="libudev-dev"/>
 </package>
 
 


### PR DESCRIPTION
Integrates the dependency to optris_drivers through a .rosinstall file.

Instructions about how to install everything are given in the Readme.

We need to wait before merging this until ohm-ros-pkg/optris_drivers#2 has been merged.
